### PR TITLE
chore: upgrade Lambda runtime to Node.js 24

### DIFF
--- a/app/src/lambdas/dynamoToRedis/dynamoToRedisLambda.ts
+++ b/app/src/lambdas/dynamoToRedis/dynamoToRedisLambda.ts
@@ -10,13 +10,12 @@ import { createRedisWriteClient } from '../../lib/redis_utils/redisClientUtils';
 /**
  * A Lambda that receives DynamoDB stream events and replicates the data to Redis
  */
-export const handler: DynamoDBStreamHandler = async (event: DynamoDBStreamEvent, context, callback) => {
+export const handler: DynamoDBStreamHandler = async (event) => {
     console.info(`DynamoDB to Redis: processing ${event?.Records?.length} records`);
     const { itemsToSave, pathsToDelete } = toRedisItems(event);
     console.info(`DynamoDB to Redis: saving ${itemsToSave.length} items and deleting ${pathsToDelete.length}`);
-    syncToRedis(itemsToSave, pathsToDelete);
+    await syncToRedis(itemsToSave, pathsToDelete);
     console.info(`DynamoDB to Redis: processed ${event?.Records?.length} records`);
-    callback(null);
 };
 
 /** Extract Redis items from DynamoDB stream event */

--- a/app/src/lambdas/processImageUpload/processImageUploadLambda.ts
+++ b/app/src/lambdas/processImageUpload/processImageUploadLambda.ts
@@ -1,4 +1,4 @@
-import { Context, Handler, S3Event } from 'aws-lambda';
+import { S3Handler } from 'aws-lambda';
 import { processImageUpload } from './processImageUpload';
 import { isValidAlbumPath, isValidImagePath } from '../../lib/gallery_path_utils/galleryPathUtils';
 
@@ -6,7 +6,7 @@ import { isValidAlbumPath, isValidImagePath } from '../../lib/gallery_path_utils
  * A Lambda that processes an image uploaded to S3.
  * Extracts metadata from image and saves entry to DynamoDB.
  */
-export const handler: Handler = async (event: S3Event, context: Context, callback) => {
+export const handler: S3Handler = async (event) => {
     const record = event.Records[0];
 
     console.info(`Image Processor: got event [${record?.eventName}]`);
@@ -19,23 +19,25 @@ export const handler: Handler = async (event: S3Event, context: Context, callbac
     ) {
         const msg = `Image processor: triggered by unexpected event [${record?.eventName}]. There's probably a misconfiguration.`;
         console.error(msg);
-        if (!!callback) callback(msg); // this prevents S3 from attempting to retry calling this lambda
+        // Return normally to prevent S3 from retrying
+        return;
     }
+
     // Don't handle files that aren't images in the right folder structure
-    else {
-        const imagePath = '/' + record?.s3?.object?.key;
-        if (!isValidImagePath(imagePath)) {
-            let msg;
-            if (isValidAlbumPath(imagePath)) {
-                msg = `Image Processor: album folder created [${imagePath}].  Probably Dean created via AWS S3 Console`;
-                console.info(msg);
-            } else {
-                msg = `Image Processor: invalid image path [${imagePath}].  Probably Dean uploaded via AWS S3 Console`;
-                console.error(msg);
-            }
-            if (!!callback) callback(msg); // this prevents S3 from attempting to retry calling this lambda
+    const imagePath = '/' + record?.s3?.object?.key;
+    if (!isValidImagePath(imagePath)) {
+        if (isValidAlbumPath(imagePath)) {
+            console.info(
+                `Image Processor: album folder created [${imagePath}].  Probably Dean created via AWS S3 Console`,
+            );
         } else {
-            await processImageUpload(record?.s3?.bucket?.name, record?.s3?.object?.key, record?.s3?.object?.versionId);
+            console.error(
+                `Image Processor: invalid image path [${imagePath}].  Probably Dean uploaded via AWS S3 Console`,
+            );
         }
+        // Return normally to prevent S3 from retrying
+        return;
     }
+
+    await processImageUpload(record?.s3?.bucket?.name, record?.s3?.object?.key, record?.s3?.object?.versionId);
 };

--- a/template.yaml
+++ b/template.yaml
@@ -81,7 +81,7 @@ Conditions:
 # -----------------------------------------------------------------------------
 Globals:
   Function:
-    Runtime: nodejs20.x
+    Runtime: nodejs24.x
     MemorySize: 256
     Timeout: 100 # TODO decrease this; the default is 3!
     LoggingConfig:


### PR DESCRIPTION
## Summary
Upgrade Lambda runtime from Node.js 20 to Node.js 24.

- Update `template.yaml` runtime from `nodejs20.x` to `nodejs24.x`
- Fix callback-based handlers deprecated in Node.js 24:
  - `processImageUploadLambda`: use `S3Handler` type, remove callback parameter
  - `dynamoToRedisLambda`: remove callback parameter, add missing `await`

Node.js 24 Lambda runtime removes support for callback-based handlers. All handlers must use async/await pattern only.

## Test plan
- [x] Deployed to staging
- [x] Verified photo uploads work (creates album, processes images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated Node.js runtime to version 24.x for improved performance and security.

* **Refactor**
  - Improved Lambda handler implementations to enhance reliability and error handling with streamlined processing logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->