### PR TITLE
chore(ci): add esbuild to deploy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
               with:
                   use-installer: true
 
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,6 +65,11 @@ jobs:
               with:
                   use-installer: true
 
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:


### PR DESCRIPTION
## Summary

Add esbuild installation to deploy jobs. Each GitHub Actions job runs on a fresh runner, so esbuild must be installed in both build-and-test and deploy jobs.

## Test plan

- [ ] CI workflow passes and deploys to staging successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to ensure proper build tool installation during both development and production deployment phases.
  * Enhanced pipeline configuration to include necessary build environment prerequisites across multiple workflow stages for improved build reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->