### PR TITLE
fix(sync): add throttling to diagnose mode

### DIFF
--- a/app/src/lib/gallery/syncRedis/syncRedis.ts
+++ b/app/src/lib/gallery/syncRedis/syncRedis.ts
@@ -112,7 +112,7 @@ export async function syncRedis(options: SyncOptions): Promise<SyncResult> {
 
             lastEvaluatedKey = nextKey;
 
-            if (mode === 'fix' && lastEvaluatedKey) {
+            if (lastEvaluatedKey) {
                 await delay(BATCH_DELAY_MS);
             }
         } while (lastEvaluatedKey);


### PR DESCRIPTION
## Summary
Add 100ms delay between batches in diagnose mode to prevent DynamoDB throttling.

Previously only fix mode had throttling, which caused diagnose mode to overwhelm DynamoDB's provisioned capacity (3 RCUs), triggering `ProvisionedThroughputExceededException` errors.

## Test plan
- [x] Unit tests pass
- [ ] Deploy to staging and run diagnose mode without throttling errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted pagination delays to occur consistently between data retrievals regardless of operation mode, ensuring uniform behavior during browsing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->