### PR TITLE
feat(ci): add integration tests job on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,69 @@ jobs:
 
             - name: Deploy to staging
               run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
+
+    integration-test:
+        needs: build-and-test
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+                  cache: 'npm'
+                  cache-dependency-path: app/package-lock.json
+
+            - name: Install esbuild globally
+              run: npm install -g esbuild
+
+            - name: Install dependencies
+              working-directory: app
+              run: npm ci
+
+            - name: Setup AWS SAM CLI
+              uses: aws-actions/setup-sam@v2
+              with:
+                  use-installer: true
+
+            - name: SAM build
+              run: sam build
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-1
+
+            - name: Deploy to test stack
+              run: sam deploy --config-env test --no-confirm-changeset --no-fail-on-empty-changeset
+
+            - name: Get stack outputs
+              id: stack-outputs
+              run: |
+                  LAMBDA_URL=$(aws cloudformation describe-stacks \
+                    --stack-name tacocat-gallery-sam-test \
+                    --query "Stacks[0].Outputs[?OutputKey=='GenerateDerivedImageUrl'].OutputValue" \
+                    --output text)
+                  if [ -z "$LAMBDA_URL" ] || [ "$LAMBDA_URL" = "None" ]; then
+                    echo "::error::Failed to retrieve GenerateDerivedImageUrl from stack outputs"
+                    exit 1
+                  fi
+                  # Extract just the domain from the full URL (remove https:// and trailing /)
+                  DOMAIN=$(echo "$LAMBDA_URL" | sed 's|https://||' | sed 's|/$||')
+                  echo "derived_image_domain=$DOMAIN" >> "$GITHUB_OUTPUT"
+
+            - name: Run integration tests
+              working-directory: app
+              env:
+                  GALLERY_ITEM_DDB_TABLE: tacocat-gallery-sam-test-items
+                  ORIGINAL_IMAGES_BUCKET: tacocat-gallery-sam-test-original-images
+                  DERIVED_IMAGES_BUCKET: tacocat-gallery-sam-test-derived-images
+                  DERIVED_IMAGE_GENERATOR_DOMAIN: ${{ steps.stack-outputs.outputs.derived_image_domain }}
+                  GALLERY_APP_DOMAIN: test-pix.tacocat.com
+              run: npm run test:integration


### PR DESCRIPTION
## Summary
Adds integration test job to CI that runs on push to main.

- Deploys to test stack and runs integration tests in parallel with staging deploy
- Fetches Lambda URL dynamically from CloudFormation outputs instead of hardcoding

## Test plan
- [ ] Merge and verify integration-test job runs successfully on main

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests to CI that run on every push to main. The pipeline now deploys a temporary test environment and exercises full application workflows, validating runtime behavior and external integrations to catch regressions earlier and improve overall reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->