### PR TITLE
test: fix integration test failures and add Redis to test stack

### DIFF
--- a/.env.integration-test.example
+++ b/.env.integration-test.example
@@ -16,6 +16,13 @@ GALLERY_APP_DOMAIN=test-pix.tacocat.com
 # Lambda URL domain for the image resizing function
 DERIVED_IMAGE_GENERATOR_DOMAIN=CHANGEME.lambda-url.us-east-1.on.aws
 
+# Amazon AWS Region
+AWS_REGION=us-east-1
+
+# Amazon AWS Credentials
+AWS_ACCESS_KEY_ID=CHANGEME
+AWS_SECRET_ACCESS_KEY=CHANGEME
+
 # Redis connection for search indexing
 REDIS_HOST=CHANGEME.cloud.redislabs.com:port
 

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "scripts": {
         "test": "npm run compile && jest --selectProjects=unit",
-        "test:integration": "npm run compile && jest --selectProjects=integration",
+        "test:integration": "npm run compile && jest --selectProjects=integration --silent",
         "test:all": "npm run compile && jest",
         "lint": "eslint '*.ts' --quiet --fix",
         "prepare": "cd .. && husky",

--- a/app/src/test/integration/albumCreation.spec.ts
+++ b/app/src/test/integration/albumCreation.spec.ts
@@ -3,7 +3,7 @@ import { deleteAlbum } from '../../lib/gallery/deleteAlbum/deleteAlbum';
 import { getAlbumAndChildren } from '../../lib/gallery/getAlbum/getAlbum';
 import { itemExists } from '../../lib/gallery/itemExists/itemExists';
 import { getParentAndNameFromPath } from '../../lib/gallery_path_utils/galleryPathUtils';
-import { assertDynamoDBItemDoesNotExist } from './helpers/albumHelpers';
+import { cleanUpAlbum } from './helpers/albumHelpers';
 import { assertRedisItemDoesNotExist, assertRedisItemExists } from './helpers/redisHelper';
 import { updateAlbum } from '../../lib/gallery/updateAlbum/updateAlbum';
 
@@ -12,11 +12,8 @@ const albumPath = `${yearPath}08-13/`;
 const albumPath2 = `${yearPath}08-14/`;
 
 beforeAll(async () => {
-    await Promise.all([
-        assertDynamoDBItemDoesNotExist(yearPath),
-        assertDynamoDBItemDoesNotExist(albumPath),
-        assertDynamoDBItemDoesNotExist(albumPath2),
-    ]);
+    // Clean up leftover data from previous failed runs
+    await cleanUpAlbum(yearPath);
     await createAlbum(yearPath, { published: true });
 });
 
@@ -70,7 +67,7 @@ test('retrieving published album should succeed', async () => {
 });
 
 test('Album exists in Redis', async () => {
-    await assertRedisItemExists(albumPath);
+    await assertRedisItemExists(albumPath, 14000);
 }, 15000);
 
 it('should fail to create album that already exists', async () => {
@@ -86,7 +83,7 @@ test('delete succeeds on empty album', async () => {
 });
 
 test('Album no longer exists in Redis', async () => {
-    await assertRedisItemDoesNotExist(albumPath);
+    await assertRedisItemDoesNotExist(albumPath, 14000);
 }, 15000);
 
 it('create with attributes', async () => {

--- a/app/src/test/integration/albumThumbnails.spec.ts
+++ b/app/src/test/integration/albumThumbnails.spec.ts
@@ -29,8 +29,6 @@ beforeAll(async () => {
     await new Promise((r) => setTimeout(r, 4000)); // wait for image processing lambda to be triggered
 
     await Promise.all([
-        updateAlbum(albumPath, { published: true }),
-        updateAlbum(getParentFromPath(albumPath), { published: true }),
         assertDynamoDBItemExists(albumPath),
         assertDynamoDBItemExists(getParentFromPath(albumPath)),
         assertDynamoDBItemExists(imagePath1),
@@ -38,6 +36,9 @@ beforeAll(async () => {
         assertOriginalImageExists(imagePath1),
         assertOriginalImageExists(imagePath2),
     ]);
+
+    await updateAlbum(getParentFromPath(albumPath), { published: true }); // must publish parent first
+    await updateAlbum(albumPath, { published: true }); // cannot publish child before parent
 }, 10000 /* increase Jest's timeout */);
 
 afterAll(async () => {

--- a/app/src/test/integration/derivedImageCloudFront.spec.ts
+++ b/app/src/test/integration/derivedImageCloudFront.spec.ts
@@ -26,7 +26,7 @@ beforeAll(async () => {
     await assertDerivedImageDoesNotExist(imagePath);
 
     derivedImageVersionId = await uploadImage('image.jpg', imagePath);
-    derivedImagePath = `${imagePath}/${derivedImageVersionId}/jpeg/${derivedImageSize}`;
+    derivedImagePath = `${imagePath}/${derivedImageVersionId}/${derivedImageSize}`;
 
     await new Promise((r) => setTimeout(r, 4000)); // wait for image processing lambda to be triggered
 }, 10000 /* increases Jest's timeout */);

--- a/app/src/test/integration/endToEnd.spec.ts
+++ b/app/src/test/integration/endToEnd.spec.ts
@@ -1,24 +1,22 @@
-import { createAlbum } from '../../lib/gallery/createAlbum/createAlbum';
+import { createAlbumNoThrow } from '../../lib/gallery/createAlbum/createAlbum';
 import { deleteAlbum } from '../../lib/gallery/deleteAlbum/deleteAlbum';
 import { deleteImage } from '../../lib/gallery/deleteImage/deleteImage';
 import { getAlbumAndChildren } from '../../lib/gallery/getAlbum/getAlbum';
-import { getLatestAlbum } from '../../lib/gallery/getLatestAlbum/getLatestAlbum';
 import { itemExists } from '../../lib/gallery/itemExists/itemExists';
 import {
     getParentAndNameFromPath,
     isValidAlbumPath,
     isValidImagePath,
 } from '../../lib/gallery_path_utils/galleryPathUtils';
-import { getAlbumPathForToday, getUniqueImagePathForToday } from './helpers/pathHelpers';
-import { uploadImage } from './helpers/s3ImageHelper';
 import { cleanUpAlbumAndParents } from './helpers/albumHelpers';
+import { uploadImage } from './helpers/s3ImageHelper';
 
-let albumPath: string;
-let imagePath: string;
+const albumPath = '/1709/10-01/'; // unique to this suite to prevent pollution
+const imagePath = albumPath + 'image.jpg';
 
-beforeAll(() => {
-    albumPath = getAlbumPathForToday(); // use current year so that getLatestAlbum will always return something
-    imagePath = getUniqueImagePathForToday();
+beforeAll(async () => {
+    // Clean up leftover data from previous failed runs
+    await cleanUpAlbumAndParents(albumPath);
 });
 
 afterAll(async () => {
@@ -33,21 +31,7 @@ test('validate test setup', async () => {
 describe('create', () => {
     describe('album', () => {
         test('createAlbum()', async () => {
-            if (await itemExists(albumPath)) {
-                console.info(`Album [${albumPath}] already exists, skipping creation`);
-            } else {
-                await expect(createAlbum(albumPath)).resolves.not.toThrow();
-                await expect(itemExists(albumPath)).resolves.toBe(true);
-            }
-        });
-
-        test('getLatestAlbum() with empty album', async () => {
-            const album = await getLatestAlbum();
-            if (!album) throw new Error(`No latest album`);
-
-            const albumPathParts = getParentAndNameFromPath(albumPath);
-            expect(album?.itemName).toBe(albumPathParts.name);
-            expect(album?.parentPath).toBe(albumPathParts.parent);
+            await expect(createAlbumNoThrow(albumPath)).resolves.toBe(true);
         });
     });
 
@@ -65,7 +49,7 @@ describe('create', () => {
         }, 10000 /* increase Jest's timeout */);
 
         test('getAlbum() contains new image', async () => {
-            const album = await getAlbumAndChildren(albumPath);
+            const album = await getAlbumAndChildren(albumPath, true /* include unpublished */);
             if (!album) throw new Error(`No album`);
 
             const albumPathParts = getParentAndNameFromPath(albumPath);
@@ -79,7 +63,6 @@ describe('create', () => {
             expect(theChild?.parentPath).toBe(imagePathParts.parent);
         });
 
-        test.todo('getLatestAlbum() has this image as its thumbnail');
         test.todo('retrieve sized image');
         test.todo('sized image exists in derived images bucket');
     });
@@ -97,7 +80,7 @@ describe('delete', () => {
 
     describe('deleteImage()', () => {
         test('delete all images in album', async () => {
-            const children = (await getAlbumAndChildren(albumPath))?.children;
+            const children = (await getAlbumAndChildren(albumPath, true /* include unpublished */))?.children;
             if (!children) throw new Error('no children');
             for (const child of children) {
                 if (!child.parentPath) throw 'child has no parent path';
@@ -107,7 +90,7 @@ describe('delete', () => {
         }, 15000 /* increase Jest's timeout */);
 
         test('album no longer contains children', async () => {
-            const album = await getAlbumAndChildren(albumPath);
+            const album = await getAlbumAndChildren(albumPath, true /* include unpublished */);
             if (!album) throw new Error(`No album results`);
             expect(album?.children?.length).toBe(0);
         });

--- a/app/src/test/integration/imageCreation.spec.ts
+++ b/app/src/test/integration/imageCreation.spec.ts
@@ -72,7 +72,7 @@ test("Image was set as album's thumb", async () => {
 });
 
 test('Image exists in Redis', async () => {
-    await assertRedisItemExists(imagePath);
+    await assertRedisItemExists(imagePath, 14000);
 }, 15000);
 
 test('Delete image', async () => {
@@ -97,5 +97,5 @@ test('Original images bucket should no longer contain image', async () => {
 });
 
 test('Image no longer exists in Redis', async () => {
-    await assertRedisItemDoesNotExist(imagePath);
+    await assertRedisItemDoesNotExist(imagePath, 14000);
 }, 15000);

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -38,6 +38,8 @@ parameter_overrides = [
     "RedisHost=redis-14907.c321.us-east-1-2.ec2.cloud.redislabs.com:14907",
     "RedisSearchUsername=devsearcher",
     "RedisWriteUsername=devwriter",
+    "RedisSearchPasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordDev",
+    "RedisWritePasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordDev",
 ]
 confirm_changeset = true
 resolve_s3 = true
@@ -51,6 +53,11 @@ parameter_overrides = [
     "Env=test",
     "GalleryAppDomain=test-pix.tacocat.com",
     "DomainCertificateArn=arn:aws:acm:us-east-1:010410881828:certificate/9fbd8ee9-f1d1-42a5-b97c-9713ce6e076d",
+    "RedisHost=redis-16860.c321.us-east-1-2.ec2.cloud.redislabs.com:16860",
+    "RedisSearchUsername=testsearcher",
+    "RedisWriteUsername=testwriter",
+    "RedisSearchPasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordTest",
+    "RedisWritePasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordTest",
 ]
 confirm_changeset = false
 resolve_s3 = true
@@ -67,6 +74,8 @@ parameter_overrides = [
     "RedisHost=redis-13894.c321.us-east-1-2.ec2.cloud.redislabs.com:13894",
     "RedisSearchUsername=prodsearcher",
     "RedisWriteUsername=prodwriter",
+    "RedisSearchPasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordProd",
+    "RedisWritePasswordSecret=Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordProd",
 ]
 confirm_changeset = true
 resolve_s3 = true

--- a/template.yaml
+++ b/template.yaml
@@ -50,25 +50,39 @@ Parameters:
     Description: Hostname and port of the Redis search instance
     Type: String
     AllowedValues:
+      - redis-16860.c321.us-east-1-2.ec2.cloud.redislabs.com:16860 # test
       - redis-14907.c321.us-east-1-2.ec2.cloud.redislabs.com:14907 # dev
       - redis-13894.c321.us-east-1-2.ec2.cloud.redislabs.com:13894 # prod
-    Default: redis-14907.c321.us-east-1-2.ec2.cloud.redislabs.com:14907
   RedisSearchUsername:
     Description: Name of user permitted to execute a search on Redis
     Type: String
     AllowedValues:
+      - testsearcher
       - devsearcher
       - prodsearcher
-    ConstraintDescription: Must be devsearcher or prodsearcher
-    Default: devsearcher
+    ConstraintDescription: Must be testsearcher, devsearcher or prodsearcher
   RedisWriteUsername:
     Description: Name of user permitted to write to Redis
     Type: String
     AllowedValues:
+      - testwriter
       - devwriter
       - prodwriter
-    ConstraintDescription: Must be devwriter or prodwriter
-    Default: devwriter
+    ConstraintDescription: Must be testwriter, devwriter or prodwriter
+  RedisSearchPasswordSecret:
+    Description: AWS Secrets Manager reference for Redis search password
+    Type: String
+    AllowedValues:
+      - Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordTest
+      - Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordDev
+      - Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordProd
+  RedisWritePasswordSecret:
+    Description: AWS Secrets Manager reference for Redis write password
+    Type: String
+    AllowedValues:
+      - Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordTest
+      - Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordDev
+      - Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordProd
 
 # -----------------------------------------------------------------------------
 # Conditions are boolean conditions that can be used to control resources
@@ -402,9 +416,7 @@ Resources:
         Variables:
           REDIS_HOST: !Ref RedisHost
           REDIS_WRITE_USERNAME: !Ref RedisWriteUsername
-          REDIS_WRITE_PASSWORD: !If [ "IsProd",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordProd}}",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordDev}}" ]
+          REDIS_WRITE_PASSWORD: !Sub "{{resolve:secretsmanager:${RedisWritePasswordSecret}}}"
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -430,9 +442,7 @@ Resources:
           GALLERY_ITEM_DDB_TABLE: !Ref GalleryItemDDBTable
           REDIS_HOST: !Ref RedisHost
           REDIS_WRITE_USERNAME: !Ref RedisWriteUsername
-          REDIS_WRITE_PASSWORD: !If [ "IsProd",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordProd}}",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisWritePasswordDev}}" ]
+          REDIS_WRITE_PASSWORD: !Sub "{{resolve:secretsmanager:${RedisWritePasswordSecret}}}"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref GalleryItemDDBTable
@@ -466,9 +476,7 @@ Resources:
           GALLERY_ITEM_DDB_TABLE: !Ref GalleryItemDDBTable
           REDIS_HOST: !Ref RedisHost
           REDIS_SEARCH_USERNAME: !Ref RedisSearchUsername
-          REDIS_SEARCH_PASSWORD: !If [ "IsProd",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordProd}}",
-            "{{resolve:secretsmanager:Tacocat/Gallery/Authentication:SecretString:RedisSearchPasswordDev}}" ]
+          REDIS_SEARCH_PASSWORD: !Sub "{{resolve:secretsmanager:${RedisSearchPasswordSecret}}}"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref GalleryItemDDBTable


### PR DESCRIPTION
The integration tests were all kinds of broken, and this fixes them (at least on localhost).  Of major note is that we didn't even have a Redis database for integration testing before today.  We created it, and configured it in the AWS stack for integration tests.  Previously the test stack was using the dev Redis! 

- Configure Redis environment variables in template.yaml and samconfig.toml for test stack
- Use unique year paths per test suite to prevent data pollution
- Add cleanup in beforeAll to handle leftover data from failed runs
- Fix endToEnd.spec.ts to use hard-coded path instead of dynamic date
- Remove redundant getLatestAlbum test from endToEnd (tested elsewhere)
- Increase Redis assertion timeouts for CI environment
- Fix derivedImageCloudFront.spec.ts expected path to match CloudFront URL rewrite
- Add --silent flag to test:integration npm script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test setup with updated helper functions, sequential publish flow, and explicit timeout parameters for Redis assertions.

* **Chores**
  * Updated environment and infrastructure configuration for AWS and Redis parameters.
  * Configured Redis credentials management through AWS Secrets Manager across all deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->