### PR TITLE
chore: upgrade Sharp lambda layer to 0.34.5

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -381,7 +381,7 @@ Resources:
       Layers:
         # ARN of the Lambda Layer containing the Sharp image processing library
         # I tried setting this as a parameter, but it didn't update when I changed it
-        - arn:aws:lambda:us-east-1:010410881828:layer:Sharp-0_33_0:1 
+        - arn:aws:lambda:us-east-1:010410881828:layer:Sharp-0_34_5:1 
       FunctionUrlConfig:
         AuthType: NONE #TODO: authentication
     Metadata:


### PR DESCRIPTION
## Summary
Upgrade Sharp image processing lambda layer from 0.33.0 to 0.34.5.

- Layer source: [pH200/sharp-layer](https://github.com/pH200/sharp-layer)
- Tested on dev stack with image upload

## Test plan
- [ ] CI passes
- [ ] Verify image resizing works after prod deploy

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image processing library to a newer version, enabling access to the latest improvements and optimizations in image handling capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->