### PR TITLE
test: clean up stale data at start of integration tests

### DIFF
--- a/app/src/test/integration/heicConversion.spec.ts
+++ b/app/src/test/integration/heicConversion.spec.ts
@@ -4,14 +4,9 @@ import { itemExists } from '../../lib/gallery/itemExists/itemExists';
 import { updateAlbum } from '../../lib/gallery/updateAlbum/updateAlbum';
 import { findImage } from '../../lib/gallery_client/AlbumObject';
 import { getParentFromPath, isValidAlbumPath, isValidImagePath } from '../../lib/gallery_path_utils/galleryPathUtils';
-import { assertDynamoDBItemDoesNotExist, cleanUpAlbum } from './helpers/albumHelpers';
+import { cleanUpAlbum } from './helpers/albumHelpers';
 import { reallyGetNameFromPath } from './helpers/pathHelpers';
-import {
-    assertOriginalImageDoesNotExist,
-    downloadOriginalImage,
-    originalImageExists,
-    uploadImage,
-} from './helpers/s3ImageHelper';
+import { downloadOriginalImage, originalImageExists, uploadImage } from './helpers/s3ImageHelper';
 
 const yearPath = '/1712/'; // unique to this suite to prevent pollution
 const albumPath = `${yearPath}09-03/`;
@@ -22,12 +17,9 @@ beforeAll(async () => {
     expect(isValidAlbumPath(yearPath)).toBe(true);
     expect(isValidAlbumPath(albumPath)).toBe(true);
 
-    await Promise.all([
-        assertDynamoDBItemDoesNotExist(yearPath),
-        assertDynamoDBItemDoesNotExist(albumPath),
-        assertOriginalImageDoesNotExist(heicImagePath),
-        assertOriginalImageDoesNotExist(jpegImagePath),
-    ]);
+    // Clean up leftover data from previous failed runs
+    await cleanUpAlbum(albumPath);
+    await cleanUpAlbum(yearPath);
 
     // Upload HEIC file - Lambda will convert to JPEG
     await uploadImage('FullMetadataHeic.heic', heicImagePath);

--- a/app/src/test/integration/quarantine.spec.ts
+++ b/app/src/test/integration/quarantine.spec.ts
@@ -2,8 +2,8 @@ import { DeleteObjectCommand, HeadObjectCommand, NotFound, S3Client } from '@aws
 import { itemExists } from '../../lib/gallery/itemExists/itemExists';
 import { isValidAlbumPath } from '../../lib/gallery_path_utils/galleryPathUtils';
 import { getOriginalImagesBucketName } from '../../lib/lambda_utils/Env';
-import { assertDynamoDBItemDoesNotExist, cleanUpAlbum } from './helpers/albumHelpers';
-import { assertOriginalImageDoesNotExist, originalImageExists, uploadBuffer } from './helpers/s3ImageHelper';
+import { cleanUpAlbum } from './helpers/albumHelpers';
+import { originalImageExists, uploadBuffer } from './helpers/s3ImageHelper';
 
 const yearPath = '/1714/'; // unique to this suite to prevent pollution
 const albumPath = `${yearPath}01-01/`;
@@ -49,11 +49,14 @@ beforeAll(async () => {
     expect(isValidAlbumPath(yearPath)).toBe(true);
     expect(isValidAlbumPath(albumPath)).toBe(true);
 
-    await Promise.all([
-        assertDynamoDBItemDoesNotExist(yearPath),
-        assertDynamoDBItemDoesNotExist(albumPath),
-        assertOriginalImageDoesNotExist(corruptHeicPath),
-    ]);
+    // Clean up leftover data from previous failed runs
+    try {
+        await deleteQuarantinedFile(corruptHeicPath);
+    } catch {
+        // Ignore if doesn't exist
+    }
+    await cleanUpAlbum(albumPath);
+    await cleanUpAlbum(yearPath);
 
     // Upload a corrupt HEIC file (just garbage bytes)
     await uploadBuffer(Buffer.from('not a valid heic file'), corruptHeicPath);


### PR DESCRIPTION
## Summary
Replace assertions with cleanup calls at the start of `beforeAll` in HEIC integration tests.

- Prevents CI failures from stale data left by previous failed test runs
- Follows existing pattern used by `albumCreation.spec.ts` and `endToEnd.spec.ts`

## Test plan
- [ ] CI passes on this PR
- [ ] Integration tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration test cleanup logic to use proactive cleanup approach instead of assertion-based verification.
  * Enhanced test lifecycle management with improved setup and teardown procedures for quarantine and album operations.

* **Chores**
  * Removed obsolete test helper methods to streamline testing infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->