### PR TITLE
chore: update dependencies

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,16 +9,16 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-dynamodb": "^3.966.0",
-                "@aws-sdk/client-lambda": "^3.966.0",
-                "@aws-sdk/client-s3": "^3.966.0",
-                "@aws-sdk/lib-dynamodb": "^3.966.0",
-                "@aws-sdk/lib-storage": "^3.966.0",
-                "@aws-sdk/s3-request-presigner": "^3.966.0",
-                "@aws-sdk/util-dynamodb": "^3.966.0",
+                "@aws-sdk/client-dynamodb": "^3.967.0",
+                "@aws-sdk/client-lambda": "^3.967.0",
+                "@aws-sdk/client-s3": "^3.967.0",
+                "@aws-sdk/lib-dynamodb": "^3.967.0",
+                "@aws-sdk/lib-storage": "^3.967.0",
+                "@aws-sdk/s3-request-presigner": "^3.967.0",
+                "@aws-sdk/util-dynamodb": "^3.967.0",
                 "@aws-sdk/util-format-url": "^3.965.0",
                 "@nozbe/microfuzz": "^1.0.0",
-                "exifreader": "^4.35.0",
+                "exifreader": "^4.36.0",
                 "mime": "^4.1.0",
                 "redis": "^5.10.0",
                 "sharp": "^0.34.5"
@@ -28,7 +28,7 @@
                 "@eslint/js": "^9.39.2",
                 "@types/aws-lambda": "^8.10.159",
                 "@types/jest": "^30.0.0",
-                "@types/node": "^25.0.5",
+                "@types/node": "^25.0.7",
                 "aws-sdk-client-mock": "^4.1.0",
                 "dotenv": "^17.2.3",
                 "eslint": "^9.39.2",
@@ -41,7 +41,7 @@
                 "ts-jest": "^29.4.6",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.52.0"
+                "typescript-eslint": "^8.53.0"
             }
         },
         "node_modules/@aws-crypto/crc32": {
@@ -247,48 +247,48 @@
             }
         },
         "node_modules/@aws-sdk/client-dynamodb": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.966.0.tgz",
-            "integrity": "sha512-u5zA3T9L5pMDV7YBHkGec6cAhnEyiKcd+HjLdJsRBCmMvq8CDZ1+uNusiKqYc7hUi3b8RF5bzGBZphWgUJQWZA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.967.0.tgz",
+            "integrity": "sha512-7xCUaV2Y613ln08AiAKQoA6XZKAtw33KHkvJKvCXabBqyO0+Y+Qq0+WkCQvunFxW2X/GzjlNSHmqRXupEO2Pjg==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/credential-provider-node": "3.966.0",
-                "@aws-sdk/dynamodb-codec": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/credential-provider-node": "3.967.0",
+                "@aws-sdk/dynamodb-codec": "3.967.0",
                 "@aws-sdk/middleware-endpoint-discovery": "3.965.0",
                 "@aws-sdk/middleware-host-header": "3.965.0",
                 "@aws-sdk/middleware-logger": "3.965.0",
                 "@aws-sdk/middleware-recursion-detection": "3.965.0",
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/region-config-resolver": "3.965.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
                 "@aws-sdk/util-user-agent-browser": "3.965.0",
-                "@aws-sdk/util-user-agent-node": "3.966.0",
+                "@aws-sdk/util-user-agent-node": "3.967.0",
                 "@smithy/config-resolver": "^4.4.5",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/fetch-http-handler": "^5.3.8",
                 "@smithy/hash-node": "^4.2.7",
                 "@smithy/invalid-dependency": "^4.2.7",
                 "@smithy/middleware-content-length": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/middleware-retry": "^4.4.18",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/middleware-retry": "^4.4.19",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
                 "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.17",
-                "@smithy/util-defaults-mode-node": "^4.2.20",
+                "@smithy/util-defaults-mode-browser": "^4.3.18",
+                "@smithy/util-defaults-mode-node": "^4.2.21",
                 "@smithy/util-endpoints": "^3.2.7",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -301,26 +301,26 @@
             }
         },
         "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.966.0.tgz",
-            "integrity": "sha512-Bs7WbbeBUk40xNgk6td46LWbo/scwNz+ZefM4JzX5fOWFgan9nH5jcBTWNTKUt8NijNTXG7lVEIw96xhsRfKbw==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.967.0.tgz",
+            "integrity": "sha512-bGoGDYNFfgFP5GFlu41KQ1QePYr+7EglW5Qbol3V4cp9LFfT5VWvCPGAP8KznrKrvakDb8tfHiYtQymya1QDQg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/credential-provider-node": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/credential-provider-node": "3.967.0",
                 "@aws-sdk/middleware-host-header": "3.965.0",
                 "@aws-sdk/middleware-logger": "3.965.0",
                 "@aws-sdk/middleware-recursion-detection": "3.965.0",
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/region-config-resolver": "3.965.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
                 "@aws-sdk/util-user-agent-browser": "3.965.0",
-                "@aws-sdk/util-user-agent-node": "3.966.0",
+                "@aws-sdk/util-user-agent-node": "3.967.0",
                 "@smithy/config-resolver": "^4.4.5",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/eventstream-serde-browser": "^4.2.7",
                 "@smithy/eventstream-serde-config-resolver": "^4.3.7",
                 "@smithy/eventstream-serde-node": "^4.2.7",
@@ -328,21 +328,21 @@
                 "@smithy/hash-node": "^4.2.7",
                 "@smithy/invalid-dependency": "^4.2.7",
                 "@smithy/middleware-content-length": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/middleware-retry": "^4.4.18",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/middleware-retry": "^4.4.19",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
                 "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.17",
-                "@smithy/util-defaults-mode-node": "^4.2.20",
+                "@smithy/util-defaults-mode-browser": "^4.3.18",
+                "@smithy/util-defaults-mode-node": "^4.2.21",
                 "@smithy/util-endpoints": "^3.2.7",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -356,35 +356,35 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.966.0.tgz",
-            "integrity": "sha512-IckVv+A6irQyXTiJrNpfi63ZtPuk6/Iu70TnMq2DTRFK/4bD2bOvqL1IHZ2WGmZMoeWd5LI8Fn6pIwdK6g4QJQ==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.967.0.tgz",
+            "integrity": "sha512-7vDlsBqd9y0dJDjCy84WMN+1r60El97IKMGlegU+l9K2+t8+Wf8bYj/J2xfm+6Ayemje6P4nkKS9tubxBLqg+A==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "5.2.0",
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/credential-provider-node": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/credential-provider-node": "3.967.0",
                 "@aws-sdk/middleware-bucket-endpoint": "3.966.0",
                 "@aws-sdk/middleware-expect-continue": "3.965.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.966.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.967.0",
                 "@aws-sdk/middleware-host-header": "3.965.0",
                 "@aws-sdk/middleware-location-constraint": "3.965.0",
                 "@aws-sdk/middleware-logger": "3.965.0",
                 "@aws-sdk/middleware-recursion-detection": "3.965.0",
-                "@aws-sdk/middleware-sdk-s3": "3.966.0",
+                "@aws-sdk/middleware-sdk-s3": "3.967.0",
                 "@aws-sdk/middleware-ssec": "3.965.0",
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/region-config-resolver": "3.965.0",
-                "@aws-sdk/signature-v4-multi-region": "3.966.0",
+                "@aws-sdk/signature-v4-multi-region": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
                 "@aws-sdk/util-user-agent-browser": "3.965.0",
-                "@aws-sdk/util-user-agent-node": "3.966.0",
+                "@aws-sdk/util-user-agent-node": "3.967.0",
                 "@smithy/config-resolver": "^4.4.5",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/eventstream-serde-browser": "^4.2.7",
                 "@smithy/eventstream-serde-config-resolver": "^4.3.7",
                 "@smithy/eventstream-serde-node": "^4.2.7",
@@ -395,21 +395,21 @@
                 "@smithy/invalid-dependency": "^4.2.7",
                 "@smithy/md5-js": "^4.2.7",
                 "@smithy/middleware-content-length": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/middleware-retry": "^4.4.18",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/middleware-retry": "^4.4.19",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
                 "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.17",
-                "@smithy/util-defaults-mode-node": "^4.2.20",
+                "@smithy/util-defaults-mode-browser": "^4.3.18",
+                "@smithy/util-defaults-mode-node": "^4.2.21",
                 "@smithy/util-endpoints": "^3.2.7",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -423,44 +423,44 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.966.0.tgz",
-            "integrity": "sha512-hQZDQgqRJclALDo9wK+bb5O+VpO8JcjImp52w9KPSz9XveNRgE9AYfklRJd8qT2Bwhxe6IbnqYEino2wqUMA1w==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.967.0.tgz",
+            "integrity": "sha512-7RgUwHcRMJtWme6kCHGUVT+Rn9GmNH+FHm34N9UgMXzUqQlzFMweE7T5E9O8nv3wIp7xFNB20ADaCw9Xdnox1Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/middleware-host-header": "3.965.0",
                 "@aws-sdk/middleware-logger": "3.965.0",
                 "@aws-sdk/middleware-recursion-detection": "3.965.0",
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/region-config-resolver": "3.965.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
                 "@aws-sdk/util-user-agent-browser": "3.965.0",
-                "@aws-sdk/util-user-agent-node": "3.966.0",
+                "@aws-sdk/util-user-agent-node": "3.967.0",
                 "@smithy/config-resolver": "^4.4.5",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/fetch-http-handler": "^5.3.8",
                 "@smithy/hash-node": "^4.2.7",
                 "@smithy/invalid-dependency": "^4.2.7",
                 "@smithy/middleware-content-length": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/middleware-retry": "^4.4.18",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/middleware-retry": "^4.4.19",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
                 "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.17",
-                "@smithy/util-defaults-mode-node": "^4.2.20",
+                "@smithy/util-defaults-mode-browser": "^4.3.18",
+                "@smithy/util-defaults-mode-node": "^4.2.21",
                 "@smithy/util-endpoints": "^3.2.7",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -472,19 +472,19 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.966.0.tgz",
-            "integrity": "sha512-QaRVBHD1prdrFXIeFAY/1w4b4S0EFyo/ytzU+rCklEjMRT7DKGXGoHXTWLGz+HD7ovlS5u+9cf8a/LeSOEMzww==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.967.0.tgz",
+            "integrity": "sha512-sJmuP7GrVmlbO6DpXkuf9Mbn6jGNNvy6PLawvaxVF150c8bpNk3w39rerRls6q1dot1dBFV2D29hBXMY1agNMg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/xml-builder": "3.965.0",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/signature-v4": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-middleware": "^4.2.7",
@@ -509,12 +509,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.966.0.tgz",
-            "integrity": "sha512-sxVKc9PY0SH7jgN/8WxhbKQ7MWDIgaJv1AoAKJkhJ+GM5r09G5Vb2Vl8ALYpsy+r8b+iYpq5dGJj8k2VqxoQMg==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.967.0.tgz",
+            "integrity": "sha512-+XWw0+f/txeMbEVRtTFZhgSw1ymH1ffaVKkdMBSnw48rfSohJElKmitCqdihagRTZpzh7m8qI6tIQ5t3OUqugw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/types": "^4.11.0",
@@ -525,18 +525,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.966.0.tgz",
-            "integrity": "sha512-VTJDP1jOibVtc5pn5TNE12rhqOO/n10IjkoJi8fFp9BMfmh3iqo70Ppvphz/Pe/R9LcK5Z3h0Z4EB9IXDR6kag==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.967.0.tgz",
+            "integrity": "sha512-0/GIAEv5pY5htg6IBMuYccBgzz3oS2DqHjHi396ziTrwlhbrCNX96AbNhQhzAx3LBZUk13sPfeapjyQ7G57Ekg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/fetch-http-handler": "^5.3.8",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-stream": "^4.5.8",
                 "tslib": "^2.6.2"
@@ -546,19 +546,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.966.0.tgz",
-            "integrity": "sha512-4oQKkYMCUx0mffKuH8LQag1M4Fo5daKVmsLAnjrIqKh91xmCrcWlAFNMgeEYvI1Yy125XeNSaFMfir6oNc2ODA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.967.0.tgz",
+            "integrity": "sha512-U8dMpaM6Qf6+2Qvp1uG6OcWv1RlrZW7tQkpmzEVWH8HZTGrVHIXXju64NMtIOr7yOnNwd0CKcytuD1QG+phCwQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/credential-provider-env": "3.966.0",
-                "@aws-sdk/credential-provider-http": "3.966.0",
-                "@aws-sdk/credential-provider-login": "3.966.0",
-                "@aws-sdk/credential-provider-process": "3.966.0",
-                "@aws-sdk/credential-provider-sso": "3.966.0",
-                "@aws-sdk/credential-provider-web-identity": "3.966.0",
-                "@aws-sdk/nested-clients": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/credential-provider-env": "3.967.0",
+                "@aws-sdk/credential-provider-http": "3.967.0",
+                "@aws-sdk/credential-provider-login": "3.967.0",
+                "@aws-sdk/credential-provider-process": "3.967.0",
+                "@aws-sdk/credential-provider-sso": "3.967.0",
+                "@aws-sdk/credential-provider-web-identity": "3.967.0",
+                "@aws-sdk/nested-clients": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/property-provider": "^4.2.7",
@@ -571,13 +571,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.966.0.tgz",
-            "integrity": "sha512-wD1KlqLyh23Xfns/ZAPxebwXixoJJCuDbeJHFrLDpP4D4h3vA2S8nSFgBSFR15q9FhgRfHleClycf6g5K4Ww6w==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.967.0.tgz",
+            "integrity": "sha512-kbvZsZL6CBlfnb71zuJdJmBUFZN5utNrcziZr/DZ2olEOkA9vlmizE8i9BUIbmS7ptjgvRnmcY1A966yfhiblw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/nested-clients": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/nested-clients": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
@@ -590,17 +590,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.966.0.tgz",
-            "integrity": "sha512-7QCOERGddMw7QbjE+LSAFgwOBpPv4px2ty0GCK7ZiPJGsni2EYmM4TtYnQb9u1WNHmHqIPWMbZR0pKDbyRyHlQ==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.967.0.tgz",
+            "integrity": "sha512-WuNbHs9rfKKSVok4+OBrZf0AHfzDgFYYMxN2G/q6ZfUmY4QmiPyxV5HkNFh1rqDxS9VV6kAZPo0EBmry10idSg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.966.0",
-                "@aws-sdk/credential-provider-http": "3.966.0",
-                "@aws-sdk/credential-provider-ini": "3.966.0",
-                "@aws-sdk/credential-provider-process": "3.966.0",
-                "@aws-sdk/credential-provider-sso": "3.966.0",
-                "@aws-sdk/credential-provider-web-identity": "3.966.0",
+                "@aws-sdk/credential-provider-env": "3.967.0",
+                "@aws-sdk/credential-provider-http": "3.967.0",
+                "@aws-sdk/credential-provider-ini": "3.967.0",
+                "@aws-sdk/credential-provider-process": "3.967.0",
+                "@aws-sdk/credential-provider-sso": "3.967.0",
+                "@aws-sdk/credential-provider-web-identity": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/property-provider": "^4.2.7",
@@ -613,12 +613,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.966.0.tgz",
-            "integrity": "sha512-q5kCo+xHXisNbbPAh/DiCd+LZX4wdby77t7GLk0b2U0/mrel4lgy6o79CApe+0emakpOS1nPZS7voXA7vGPz4w==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.967.0.tgz",
+            "integrity": "sha512-sNCY5JDV0whsfsZ6c2+6eUwH33H7UhKbqvCPbEYlIIa8wkGjCtCyFI3zZIJHVcMKJJ3117vSUFHEkNA7g+8rtw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -630,14 +630,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.966.0.tgz",
-            "integrity": "sha512-Rv5aEfbpqsQZzxpX2x+FbSyVFOE3Dngome+exNA8jGzc00rrMZEUnm3J3yAsLp/I2l7wnTfI0r2zMe+T9/nZAQ==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.967.0.tgz",
+            "integrity": "sha512-0K6kITKNytFjk1UYabYUsTThgU6TQkyW6Wmt8S5zd1A/up7NSQGpp58Rpg9GIf4amQDQwb+p9FGG7emmV8FEeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.966.0",
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/token-providers": "3.966.0",
+                "@aws-sdk/client-sso": "3.967.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/token-providers": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -649,13 +649,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.966.0.tgz",
-            "integrity": "sha512-Yv1lc9iic9xg3ywMmIAeXN1YwuvfcClLVdiF2y71LqUgIOupW8B8my84XJr6pmOQuKzZa++c2znNhC9lGsbKyw==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.967.0.tgz",
+            "integrity": "sha512-Vkr7S2ec7q/v8i/MzkHcBEdqqfWz3lyb8FDjb+NjslEwdxC3f6XwADRZzWwV1pChfx6SbsvJXKfkcF/pKAelhA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/nested-clients": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/nested-clients": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -667,14 +667,14 @@
             }
         },
         "node_modules/@aws-sdk/dynamodb-codec": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.966.0.tgz",
-            "integrity": "sha512-wxVtcbBw4oUwq8+/4GH89ODdwXGQeknk27eIvP6471G7Ak4hNPlsshD8bZNeKbMlxTMqnu7Av5TTznfTtujjFw==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.967.0.tgz",
+            "integrity": "sha512-s/0RHHt7GOeXtj0AIczyWsAjryS1w/6boLG1owCckCTtVpcTvVU/6USZz7rPPFktmPpL84+R9M8y3Tiz6u7p7w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@smithy/core": "^3.20.1",
-                "@smithy/smithy-client": "^4.10.3",
+                "@aws-sdk/core": "3.967.0",
+                "@smithy/core": "^3.20.2",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-base64": "^4.3.0",
                 "tslib": "^2.6.2"
@@ -683,7 +683,7 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-dynamodb": "^3.966.0"
+                "@aws-sdk/client-dynamodb": "3.967.0"
             }
         },
         "node_modules/@aws-sdk/endpoint-cache": {
@@ -700,15 +700,15 @@
             }
         },
         "node_modules/@aws-sdk/lib-dynamodb": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.966.0.tgz",
-            "integrity": "sha512-AjzokdL0vvybFsEThuu20p4jV3HrWxOHl8h5rrkt7bX2+21IR/P9HUXlHi5Els4rzDgxgA0Vpx4zo6ozTzUkSA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.967.0.tgz",
+            "integrity": "sha512-jxzgZkBuUVHmjJzHJPQgyhqfSilf+hQUVZlYZ7Lu6ojgZSw0jDN9H7f6doQWHNWCn+o0cRLy0kVCFcl8SNc6/Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/util-dynamodb": "3.966.0",
-                "@smithy/core": "^3.20.1",
-                "@smithy/smithy-client": "^4.10.3",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/util-dynamodb": "3.967.0",
+                "@smithy/core": "^3.20.2",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -716,18 +716,18 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-dynamodb": "^3.966.0"
+                "@aws-sdk/client-dynamodb": "3.967.0"
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.966.0.tgz",
-            "integrity": "sha512-hI+tsvfbIIyA/4Z3uIQYpmsZCe2Nd/FbJEhUhT4AubxABQcJt3LZ9e2vo9ukJAqVh+p1gBgnSpriVxWgknRSDA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.967.0.tgz",
+            "integrity": "sha512-w8+Cm17bTI+dP5hjYljSAs/yCA4SmiweRt8N7iFGPJJ3j5gaQh9O/of50F2taHLeidkE6ysHh83FA3/gAhWwPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/abort-controller": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "buffer": "5.6.0",
                 "events": "3.3.0",
                 "stream-browserify": "3.0.0",
@@ -737,7 +737,7 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.966.0"
+                "@aws-sdk/client-s3": "3.967.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -791,15 +791,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.966.0.tgz",
-            "integrity": "sha512-0/ofXeceTH/flKhg4EGGYr4cDtaLVkR/2RI05J/hxrHIls+iM6j8++GO0TocxmZYK+8B+7XKSaV9LU26nboTUQ==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.967.0.tgz",
+            "integrity": "sha512-RuOan0fknnAep2pTSjmJ+Heomowxg3M3s+pcs0JEW/SYnvdwYhFOTcFg2VBvGv3V1kwXxXHMlC57zoGn6pNcqg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
                 "@aws-crypto/crc32c": "5.2.0",
                 "@aws-crypto/util": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/crc64-nvme": "3.965.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/is-array-buffer": "^4.2.0",
@@ -875,19 +875,19 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.966.0.tgz",
-            "integrity": "sha512-9N9zncsY5ydDCRatKdrPZcdCwNWt7TdHmqgwQM52PuA5gs1HXWwLLNDy/51H+9RTHi7v6oly+x9utJ/qypCh2g==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.967.0.tgz",
+            "integrity": "sha512-Kkd6xGwTqbg7Spq1SI3ZX6PPYKdGLxdRGlXGNE3lnEPzNueQZQJKLZFpOY2aVdcAT+ytAY96N5szeeeAsFdUaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-arn-parser": "3.966.0",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/signature-v4": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-config-provider": "^4.2.0",
                 "@smithy/util-middleware": "^4.2.7",
@@ -914,15 +914,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.966.0.tgz",
-            "integrity": "sha512-MvGoy0vhMluVpSB5GaGJbYLqwbZfZjwEZhneDHdPhgCgQqmCtugnYIIjpUw7kKqWGsmaMQmNEgSFf1zYYmwOyg==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.967.0.tgz",
+            "integrity": "sha512-2qzJzZj5u+cZiG7kz3XJPaTH4ssUY/aet1kwJsUTFKrWeHUf7mZZkDFfkXP5cOffgiOyR5ZkrmJoLKAde9hshg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
@@ -932,44 +932,44 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.966.0.tgz",
-            "integrity": "sha512-FRzAWwLNoKiaEWbYhnpnfartIdOgiaBLnPcd3uG1Io+vvxQUeRPhQIy4EfKnT3AuA+g7gzSCjMG2JKoJOplDtQ==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.967.0.tgz",
+            "integrity": "sha512-PYa7V8w0gaNux6Sz/Z7zrHmPloEE+EKpRxQIOG/D0askTr5Yd4oO2KGgcInf65uHK3f0Z9U4CTUGHZvQvABypA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
                 "@aws-sdk/middleware-host-header": "3.965.0",
                 "@aws-sdk/middleware-logger": "3.965.0",
                 "@aws-sdk/middleware-recursion-detection": "3.965.0",
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/region-config-resolver": "3.965.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-endpoints": "3.965.0",
                 "@aws-sdk/util-user-agent-browser": "3.965.0",
-                "@aws-sdk/util-user-agent-node": "3.966.0",
+                "@aws-sdk/util-user-agent-node": "3.967.0",
                 "@smithy/config-resolver": "^4.4.5",
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.2",
                 "@smithy/fetch-http-handler": "^5.3.8",
                 "@smithy/hash-node": "^4.2.7",
                 "@smithy/invalid-dependency": "^4.2.7",
                 "@smithy/middleware-content-length": "^4.2.7",
-                "@smithy/middleware-endpoint": "^4.4.2",
-                "@smithy/middleware-retry": "^4.4.18",
+                "@smithy/middleware-endpoint": "^4.4.3",
+                "@smithy/middleware-retry": "^4.4.19",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-base64": "^4.3.0",
                 "@smithy/util-body-length-browser": "^4.2.0",
                 "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.17",
-                "@smithy/util-defaults-mode-node": "^4.2.20",
+                "@smithy/util-defaults-mode-browser": "^4.3.18",
+                "@smithy/util-defaults-mode-node": "^4.2.21",
                 "@smithy/util-endpoints": "^3.2.7",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -997,17 +997,17 @@
             }
         },
         "node_modules/@aws-sdk/s3-request-presigner": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.966.0.tgz",
-            "integrity": "sha512-RUxg33fhT7qOJuqcxuLMs6vS8Fy84KF6lL+G6JHO769AnJkHqGW5iVaiq+/fhkU38tGHviljyx8uIl6dBUM9KA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.967.0.tgz",
+            "integrity": "sha512-7AD5wWly5zAT8Vo3TuZJDHbStdnLVGRZaeO79NKKGQR8HdqtqtjH0AdMQkKBH0+CeFwWqZ1X1N6cY+X0x8Zn6w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/signature-v4-multi-region": "3.966.0",
+                "@aws-sdk/signature-v4-multi-region": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@aws-sdk/util-format-url": "3.965.0",
-                "@smithy/middleware-endpoint": "^4.4.2",
+                "@smithy/middleware-endpoint": "^4.4.3",
                 "@smithy/protocol-http": "^5.3.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.4",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -1016,12 +1016,12 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.966.0.tgz",
-            "integrity": "sha512-VNSpyfKtDiBg/nPwSXDvnjISaDE9mI8zhOK3C4/obqh8lK1V6j04xDlwyIWbbIM0f6VgV1FVixlghtJB79eBqA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.967.0.tgz",
+            "integrity": "sha512-LfpCEqe/BliiwBtNImz/Txx6MQZkDqjP2bbk+Q4Km6mYhFU9pyPlKo3AYEHfGWn92Smt1nS3S8SzIK0nL6J2Fg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.966.0",
+                "@aws-sdk/middleware-sdk-s3": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/signature-v4": "^5.3.7",
@@ -1033,13 +1033,13 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.966.0.tgz",
-            "integrity": "sha512-8k5cBTicTGYJHhKaweO4gL4fud1KDnLS5fByT6/Xbiu59AxYM4E/h3ds+3jxDMnniCE3gIWpEnyfM9khtmw2lA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.967.0.tgz",
+            "integrity": "sha512-Qnd/nJ0CgeUa7zQczgmdQm0vYUF7pD1G0C+dR1T7huHQHRIsgCWIsCV9wNKzOFluqtcr6YAeuTwvY0+l8XWxnA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.966.0",
-                "@aws-sdk/nested-clients": "3.966.0",
+                "@aws-sdk/core": "3.967.0",
+                "@aws-sdk/nested-clients": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -1076,9 +1076,9 @@
             }
         },
         "node_modules/@aws-sdk/util-dynamodb": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.966.0.tgz",
-            "integrity": "sha512-bc5HmvegLpMVb6zuh3/roq3i+CEacSK2RIZrHijs90r4lENAWlueZQxJz6ZvazlngfnAi1ZVCXOviPUAWKivSA==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.967.0.tgz",
+            "integrity": "sha512-Vu4JsHv7pJ2x3egmZ4IeKHzufMO3pkwbWfbcfV4uT0pVc0AIPe46fgU1P6c8YmPNCbU442rrQXxGHN5wpL1jOA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -1087,7 +1087,7 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-dynamodb": "^3.966.0"
+                "@aws-sdk/client-dynamodb": "3.967.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
@@ -1146,12 +1146,12 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.966.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.966.0.tgz",
-            "integrity": "sha512-vPPe8V0GLj+jVS5EqFz2NUBgWH35favqxliUOvhp8xBdNRkEjiZm5TqitVtFlxS4RrLY3HOndrWbrP5ejbwl1Q==",
+            "version": "3.967.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.967.0.tgz",
+            "integrity": "sha512-yUz6pCGxyG4+QaDg0dkdIBphjQp8A9rrbZa/+U3RJgRrW47hy64clFQUROzj5Poy1Ur8ICVXEUpBsSqRuYEU2g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.966.0",
+                "@aws-sdk/middleware-user-agent": "3.967.0",
                 "@aws-sdk/types": "3.965.0",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/types": "^4.11.0",
@@ -3243,9 +3243,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.20.1",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.1.tgz",
-            "integrity": "sha512-wOboSEdQ85dbKAJ0zL+wQ6b0HTSBRhtGa0PYKysQXkRg+vK0tdCRRVruiFM2QMprkOQwSYOnwF4og96PAaEGag==",
+            "version": "3.20.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.3.tgz",
+            "integrity": "sha512-iwF1e0+H9vX+4reUA0WjKnc5ueg0Leinl5kI7wsie5bVXoYdzkpINz6NPYhpr/5InOv332a7wNV5AxJyFoVUsQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/middleware-serde": "^4.2.8",
@@ -3463,12 +3463,12 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.2.tgz",
-            "integrity": "sha512-mqpAdux0BNmZu/SqkFhQEnod4fX23xxTvU2LUpmKp0JpSI+kPYCiHJMmzREr8yxbNxKL2/DU1UZm9i++ayU+2g==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.4.tgz",
+            "integrity": "sha512-TFxS6C5bGSc4djD1SLVmstCpfYDjmMnBR4KRDge5HEEtgSINGPKuxLvaAGfSPx5FFoMaTJkj4jJLNFggeWpRoQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.20.1",
+                "@smithy/core": "^3.20.3",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -3482,15 +3482,15 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.18",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.18.tgz",
-            "integrity": "sha512-E5hulijA59nBk/zvcwVMaS7FG7Y4l6hWA9vrW018r+8kiZef4/ETQaPI4oY+3zsy9f6KqDv3c4VKtO4DwwgpCg==",
+            "version": "4.4.20",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.20.tgz",
+            "integrity": "sha512-+UvEn/8HGzh/6zpe9xFGZe7go4/fzflggfeRG/TvdGLoUY7Gw+4RgzKJEPU2NvPo0k/j/o7vvx25ZWyOXeGoxw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/service-error-classification": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.5",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -3657,13 +3657,13 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.10.3",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.3.tgz",
-            "integrity": "sha512-EfECiO/0fAfb590LBnUe7rI5ux7XfquQ8LBzTe7gxw0j9QW/q8UT/EHWHlxV/+jhQ3+Ssga9uUYXCQgImGMbNg==",
+            "version": "4.10.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.5.tgz",
+            "integrity": "sha512-uotYm3WDne01R0DxBqF9J8WZc8gSgdj+uC7Lv/R+GinH4rxcgRLxLDayYkyGAboZlYszly6maQA+NGQ5N4gLhQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.20.1",
-                "@smithy/middleware-endpoint": "^4.4.2",
+                "@smithy/core": "^3.20.3",
+                "@smithy/middleware-endpoint": "^4.4.4",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
@@ -3764,13 +3764,13 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.17",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.17.tgz",
-            "integrity": "sha512-dwN4GmivYF1QphnP3xJESXKtHvkkvKHSZI8GrSKMVoENVSKW2cFPRYC4ZgstYjUHdR3zwaDkIaTDIp26JuY7Cw==",
+            "version": "4.3.19",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.19.tgz",
+            "integrity": "sha512-5fkC/yE5aepnzcF9dywKefGlJUMM7JEYUOv97TRDLTtGiiAqf7YG80HJWIBR0qWQPQW3dlQ5eFlUsySvt0rGEA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.5",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -3779,16 +3779,16 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.20",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.20.tgz",
-            "integrity": "sha512-VD/I4AEhF1lpB3B//pmOIMBNLMrtdMXwy9yCOfa2QkJGDr63vH3RqPbSAKzoGMov3iryCxTXCxSsyGmEB8PDpg==",
+            "version": "4.2.22",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.22.tgz",
+            "integrity": "sha512-f0KNaSK192+kv6GFkUDA0Tvr5B8eU2bFh1EO+cUdlzZ2jap5Zv7KZXa0B/7r/M1+xiYPSIuroxlxQVP1ua9kxg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/property-provider": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.3",
+                "@smithy/smithy-client": "^4.10.5",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -4063,9 +4063,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.0.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.5.tgz",
-            "integrity": "sha512-FuLxeLuSVOqHPxSN1fkcD8DLU21gAP7nCKqGRJ/FglbCUBs0NYN6TpHcdmyLeh8C0KwGIaZQJSv+OYG+KZz+Gw==",
+            "version": "25.0.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.7.tgz",
+            "integrity": "sha512-C/er7DlIZgRJO7WtTdYovjIFzGsz0I95UlMyR9anTb4aCpBSRWe5Jc1/RvLKUfzmOxHPGjSE5+63HgLtndxU4w==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4115,17 +4115,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
-            "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
+            "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.52.0",
-                "@typescript-eslint/type-utils": "8.52.0",
-                "@typescript-eslint/utils": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0",
+                "@typescript-eslint/scope-manager": "8.53.0",
+                "@typescript-eslint/type-utils": "8.53.0",
+                "@typescript-eslint/utils": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.4.0"
@@ -4138,23 +4138,23 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.52.0",
+                "@typescript-eslint/parser": "^8.53.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
-            "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
+            "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.52.0",
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/typescript-estree": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0",
+                "@typescript-eslint/scope-manager": "8.53.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/typescript-estree": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -4170,14 +4170,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
-            "integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
+            "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.52.0",
-                "@typescript-eslint/types": "^8.52.0",
+                "@typescript-eslint/tsconfig-utils": "^8.53.0",
+                "@typescript-eslint/types": "^8.53.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -4192,14 +4192,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
-            "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
+            "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0"
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4210,9 +4210,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
-            "integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
+            "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4227,15 +4227,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
-            "integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
+            "integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/typescript-estree": "8.52.0",
-                "@typescript-eslint/utils": "8.52.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/typescript-estree": "8.53.0",
+                "@typescript-eslint/utils": "8.53.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.4.0"
             },
@@ -4252,9 +4252,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
-            "integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
+            "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4266,16 +4266,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
-            "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
+            "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.52.0",
-                "@typescript-eslint/tsconfig-utils": "8.52.0",
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/visitor-keys": "8.52.0",
+                "@typescript-eslint/project-service": "8.53.0",
+                "@typescript-eslint/tsconfig-utils": "8.53.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/visitor-keys": "8.53.0",
                 "debug": "^4.4.3",
                 "minimatch": "^9.0.5",
                 "semver": "^7.7.3",
@@ -4294,16 +4294,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
-            "integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
+            "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.52.0",
-                "@typescript-eslint/types": "8.52.0",
-                "@typescript-eslint/typescript-estree": "8.52.0"
+                "@typescript-eslint/scope-manager": "8.53.0",
+                "@typescript-eslint/types": "8.53.0",
+                "@typescript-eslint/typescript-estree": "8.53.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4318,13 +4318,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
-            "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
+            "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.52.0",
+                "@typescript-eslint/types": "8.53.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5855,9 +5855,9 @@
             "license": "ISC"
         },
         "node_modules/exifreader": {
-            "version": "4.35.0",
-            "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.35.0.tgz",
-            "integrity": "sha512-qiMONyOObmwI6sIXy13vRGqlcoi9VUKr70iGI1aefP+xJsbcXp+hcyL/4J6hov/yG9UhS7Hq1OQ1hAoSEZl+RA==",
+            "version": "4.36.0",
+            "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.36.0.tgz",
+            "integrity": "sha512-A9LvILHKAlVyF8k/ThqcnvvWrtprcKLw2BRuesuqhWZzgPu+GLDfQwVlqK4QE9ytmZDC6C71mY8ij5w9fZOANg==",
             "hasInstallScript": true,
             "license": "MPL-2.0",
             "optionalDependencies": {
@@ -9025,16 +9025,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
-            "integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
+            "version": "8.53.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
+            "integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.52.0",
-                "@typescript-eslint/parser": "8.52.0",
-                "@typescript-eslint/typescript-estree": "8.52.0",
-                "@typescript-eslint/utils": "8.52.0"
+                "@typescript-eslint/eslint-plugin": "8.53.0",
+                "@typescript-eslint/parser": "8.53.0",
+                "@typescript-eslint/typescript-estree": "8.53.0",
+                "@typescript-eslint/utils": "8.53.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/app/package.json
+++ b/app/package.json
@@ -14,16 +14,16 @@
         "agent-docs": "node ../scripts/build-agent-docs.mjs"
     },
     "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.966.0",
-        "@aws-sdk/client-lambda": "^3.966.0",
-        "@aws-sdk/client-s3": "^3.966.0",
-        "@aws-sdk/lib-dynamodb": "^3.966.0",
-        "@aws-sdk/lib-storage": "^3.966.0",
-        "@aws-sdk/s3-request-presigner": "^3.966.0",
-        "@aws-sdk/util-dynamodb": "^3.966.0",
+        "@aws-sdk/client-dynamodb": "^3.967.0",
+        "@aws-sdk/client-lambda": "^3.967.0",
+        "@aws-sdk/client-s3": "^3.967.0",
+        "@aws-sdk/lib-dynamodb": "^3.967.0",
+        "@aws-sdk/lib-storage": "^3.967.0",
+        "@aws-sdk/s3-request-presigner": "^3.967.0",
+        "@aws-sdk/util-dynamodb": "^3.967.0",
         "@aws-sdk/util-format-url": "^3.965.0",
         "@nozbe/microfuzz": "^1.0.0",
-        "exifreader": "^4.35.0",
+        "exifreader": "^4.36.0",
         "mime": "^4.1.0",
         "redis": "^5.10.0",
         "sharp": "^0.34.5"
@@ -33,7 +33,7 @@
         "@eslint/js": "^9.39.2",
         "@types/aws-lambda": "^8.10.159",
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.0.5",
+        "@types/node": "^25.0.7",
         "aws-sdk-client-mock": "^4.1.0",
         "dotenv": "^17.2.3",
         "eslint": "^9.39.2",
@@ -46,7 +46,7 @@
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.52.0"
+        "typescript-eslint": "^8.53.0"
     },
     "lint-staged": {
         "*.{js,ts,svelte,json,css,html,md}": "prettier --write",


### PR DESCRIPTION
## Summary
Update npm dependencies to latest versions.

- @aws-sdk/* 3.966.0 → 3.967.0
- @types/node 25.0.5 → 25.0.7
- exifreader 4.35.0 → 4.36.0 (adds includeTags/excludeTags filtering)
- typescript-eslint 8.52.0 → 8.53.0 (adds auto-fix for unused imports)

## Test plan
- [x] Unit tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)