### PR TITLE
fix(upload): merge tags on image re-upload and filter empty values

### DIFF
--- a/app/src/lib/gallery/upsertImage/upsertImage.spec.ts
+++ b/app/src/lib/gallery/upsertImage/upsertImage.spec.ts
@@ -1,11 +1,16 @@
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
-import { upsertImage } from './upsertImage';
+import { DynamoDBDocumentClient, GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { mergeTags, upsertImage } from './upsertImage';
 import { ImageCreateRequest } from '../galleryTypes';
 
 const mockDocClient = mockClient(DynamoDBDocumentClient);
 
 const imagePath = '/2001/12-31/image.jpg';
+
+beforeEach(() => {
+    // Default mock for GetCommand - return empty Item (no existing tags)
+    mockDocClient.on(GetCommand).resolves({ Item: {} });
+});
 
 afterEach(() => {
     mockDocClient.reset();
@@ -39,4 +44,70 @@ test('description', async () => {
     expect(updateInput.ExpressionAttributeValues?.[':versionId']).toEqual('123');
     expect(updateInput.UpdateExpression).toContain('description = if_not_exists(description, :description)');
     expect(updateInput.ExpressionAttributeValues?.[':description']).toEqual('Desc 1');
+});
+
+// mergeTags helper function tests
+describe('mergeTags', () => {
+    test('both undefined returns undefined', () => {
+        expect(mergeTags(undefined, undefined)).toBeUndefined();
+    });
+
+    test('existing only returns existing', () => {
+        expect(mergeTags(['A', 'B'], undefined)).toEqual(['A', 'B']);
+    });
+
+    test('incoming only returns incoming', () => {
+        expect(mergeTags(undefined, ['A', 'B'])).toEqual(['A', 'B']);
+    });
+
+    test('merges and deduplicates', () => {
+        expect(mergeTags(['A'], ['A', 'B'])).toEqual(['A', 'B']);
+    });
+
+    test('filters empty strings', () => {
+        expect(mergeTags(['', 'A', '  '], ['B', ''])).toEqual(['A', 'B']);
+    });
+
+    test('empty arrays return undefined', () => {
+        expect(mergeTags([], [])).toBeUndefined();
+    });
+});
+
+// upsertImage tag behavior tests
+describe('upsertImage tags', () => {
+    test('empty array not saved', async () => {
+        await upsertImage(imagePath, { versionId: '123', tags: [] });
+        const updateInput = mockDocClient.commandCalls(UpdateCommand)?.[0]?.args[0]?.input;
+        if (!updateInput) throw new Error('No update command');
+        expect(updateInput.UpdateExpression).not.toContain('tags');
+        expect(updateInput.ExpressionAttributeValues?.[':tags']).toBeUndefined();
+    });
+
+    test('null not saved', async () => {
+        await upsertImage(imagePath, { versionId: '123', tags: null as unknown as string[] });
+        const updateInput = mockDocClient.commandCalls(UpdateCommand)?.[0]?.args[0]?.input;
+        if (!updateInput) throw new Error('No update command');
+        expect(updateInput.UpdateExpression).not.toContain('tags');
+        expect(updateInput.ExpressionAttributeValues?.[':tags']).toBeUndefined();
+    });
+
+    test('merges with existing', async () => {
+        mockDocClient.on(GetCommand).resolves({ Item: { tags: ['A'] } });
+        await upsertImage(imagePath, { versionId: '123', tags: ['B'] });
+        const updateInput = mockDocClient.commandCalls(UpdateCommand)?.[0]?.args[0]?.input;
+        if (!updateInput) throw new Error('No update command');
+        expect(updateInput.UpdateExpression).toContain('tags = :tags');
+        expect(updateInput.ExpressionAttributeValues?.[':tags']).toEqual(['A', 'B']);
+    });
+
+    test('existing preserved when incoming empty', async () => {
+        mockDocClient.on(GetCommand).resolves({ Item: { tags: ['A'] } });
+        await upsertImage(imagePath, { versionId: '123', tags: [] });
+        const updateInput = mockDocClient.commandCalls(UpdateCommand)?.[0]?.args[0]?.input;
+        if (!updateInput) throw new Error('No update command');
+        // When incoming is empty, merged result is just existing ['A']
+        // So tags SHOULD be in the update expression
+        expect(updateInput.UpdateExpression).toContain('tags = :tags');
+        expect(updateInput.ExpressionAttributeValues?.[':tags']).toEqual(['A']);
+    });
 });

--- a/app/src/lib/gallery/upsertImage/upsertImage.ts
+++ b/app/src/lib/gallery/upsertImage/upsertImage.ts
@@ -1,4 +1,4 @@
-import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { getParentAndNameFromPath, isValidImagePath } from '../../gallery_path_utils/galleryPathUtils';
 import { BadRequestException } from '../../lambda_utils/BadRequestException';
 import { getDynamoDbTableName } from '../../lambda_utils/Env';
@@ -6,8 +6,22 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { ImageCreateRequest } from '../galleryTypes';
 
 /**
+ * Merge existing and incoming tags, deduplicating and filtering out empty values.
+ * Returns undefined if the result is empty (to avoid saving empty arrays).
+ */
+export function mergeTags(
+    existingTags: string[] | undefined,
+    incomingTags: string[] | undefined,
+): string[] | undefined {
+    const existing = existingTags ?? [];
+    const incoming = incomingTags ?? [];
+    const merged = [...new Set([...existing, ...incoming])].filter((tag) => tag != null && tag.trim() !== '');
+    return merged.length > 0 ? merged : undefined;
+}
+
+/**
  * Create or update an image in DynamoDB.
- * If update, only overwrite fields that are not already set.
+ * If update, only overwrite fields that are not already set (except tags which are merged).
  *
  * @param imagePath Path of the image to update, like /2001/12-31/image.jpg
  * @param image attributes to update
@@ -24,9 +38,25 @@ export async function upsertImage(imagePath: string, image: ImageCreateRequest):
         if (!validKeys.has(key)) throw new BadRequestException(`Invalid attribute: [${key}]`);
     });
 
-    // Construct the DynamoDB command
     const pathParts = getParentAndNameFromPath(imagePath);
     if (!pathParts.name) throw 'Expecting path to have a leaf, got none';
+
+    const ddbClient = new DynamoDBClient({});
+    const docClient = DynamoDBDocumentClient.from(ddbClient);
+
+    // Fetch existing tags to merge with incoming tags
+    const getCommand = new GetCommand({
+        TableName: getDynamoDbTableName(),
+        Key: {
+            parentPath: pathParts.parent,
+            itemName: pathParts.name,
+        },
+        ProjectionExpression: 'tags',
+    });
+    const existingItem = await docClient.send(getCommand);
+    const existingTags = existingItem.Item?.tags as string[] | undefined;
+
+    // Construct the DynamoDB update command
     const now = new Date().toISOString();
     const ddbCommand = new UpdateCommand({
         TableName: getDynamoDbTableName(),
@@ -50,26 +80,25 @@ export async function upsertImage(imagePath: string, image: ImageCreateRequest):
     let updateExpression = ddbCommand.input.UpdateExpression;
     const expressionAttributeValues = ddbCommand.input.ExpressionAttributeValues;
     if (!updateExpression || !expressionAttributeValues) throw new Error('Malformed UpdateCommand');
-    if (!!image.title) {
+    if (image.title) {
         updateExpression += `, title = if_not_exists(title, :title)`;
         expressionAttributeValues[':title'] = image.title;
     }
-    if (!!image.description) {
+    if (image.description) {
         updateExpression += `, description = if_not_exists(description, :description)`;
         expressionAttributeValues[':description'] = image.description;
     }
-    if (!!image.tags) {
-        updateExpression += `, tags = if_not_exists(tags, :tags)`;
-        expressionAttributeValues[':tags'] = image.tags;
+    const mergedTags = mergeTags(existingTags, image.tags);
+    if (mergedTags) {
+        updateExpression += `, tags = :tags`;
+        expressionAttributeValues[':tags'] = mergedTags;
     }
-    if (!!image.dimensions) {
+    if (image.dimensions) {
         updateExpression += `, dimensions = :dimensions`;
         expressionAttributeValues[':dimensions'] = image.dimensions;
     }
     ddbCommand.input.UpdateExpression = updateExpression;
 
-    // Send command to DynamoDB
-    const ddbClient = new DynamoDBClient({});
-    const docClient = DynamoDBDocumentClient.from(ddbClient);
+    // Send update command to DynamoDB
     await docClient.send(ddbCommand);
 }


### PR DESCRIPTION
## Summary

Fixes two bugs related to image tags:
- Uploading an image with no embedded IPTC/XMP tags could save null or empty values to DynamoDB
- Re-uploading an image wasn't merging tags - new tags were ignored if DynamoDB already had any value (including null)

Now tags are properly merged (union, deduplicated) and empty values are filtered out.

## Test plan

- [x] Unit tests pass (752 tests)
- [x] Manual test: Upload image with empty/whitespace tag → no tags attribute in DynamoDB
- [x] Manual test: Upload image with tags, re-upload with different tags → tags merged

Closes #108

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image gallery tagging now intelligently merges incoming tags with existing tags and removes duplicates. Empty or null tag arrays are not saved.

* **Tests**
  * Added comprehensive test coverage for tag merging functionality, including validation for edge cases, deduplication, empty strings, and empty array scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->