### PR TITLE
chore(test): increase integration test timeout to 30s

### DIFF
--- a/app/jest.setup.integration.ts
+++ b/app/jest.setup.integration.ts
@@ -6,4 +6,7 @@
  * locally, or CI secrets in GitHub Actions).
  */
 
+// Increase default timeout for integration tests (AWS operations can be slow)
+jest.setTimeout(30000);
+
 process.env.AWS_REGION ??= 'us-east-1';


### PR DESCRIPTION
## Summary
Increase Jest timeout for integration tests from 5s (default) to 30s to prevent flaky timeout failures in CI.

- Integration tests hit real AWS resources which can have variable latency
- Random tests were timing out in beforeAll/afterAll hooks

## Test plan
- [x] Verified locally that 6-second beforeAll hook passes (would fail with 5s default)
- [ ] CI integration tests pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased Jest test timeout to 30 seconds for improved test reliability.

* **Chores**
  * Updated default AWS region configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->