### PR TITLE
fix(search): broken video indexing & search

### DIFF
--- a/app/src/lib/redis_utils/redisMset.ts
+++ b/app/src/lib/redis_utils/redisMset.ts
@@ -1,6 +1,6 @@
 import { RedisGalleryItem } from './redisTypes';
 import { RedisClient } from './redisClientUtils';
-import { isValidImagePath } from '../gallery_path_utils/galleryPathUtils';
+import { isValidMediaPath } from '../gallery_path_utils/galleryPathUtils';
 
 /**
  * Save the items to Redis.
@@ -18,5 +18,5 @@ function toPath(item: RedisGalleryItem): string {
     if (!item.parentPath) throw new Error(`Missing parentPath for ${item}`);
     if (!item.itemName) throw new Error(`Missing itemName for ${item}`);
     const path = `${item.parentPath}${item.itemName}`;
-    return isValidImagePath(path) ? path : path + '/';
+    return isValidMediaPath(path) ? path : path + '/';
 }


### PR DESCRIPTION
## Summary
- Fix video search returning incorrect paths with trailing slash
- Videos were stored in Redis with paths like `/2026/01-20/my_video.mov/` instead of `/2026/01-20/my_video.mov`
- Root cause: `redisMset.ts` used `isValidImagePath()` instead of `isValidMediaPath()`

## Test plan
- [x] Unit tests pass
- [ ] Deploy to staging and verify video search works
- [ ] Edit an existing video to update its Redis entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal validation logic to improve file type handling consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->