### PR TITLE
fix: renames timing out

### DIFF
--- a/app/src/lib/gallery_path_utils/galleryPathUtils.spec.ts
+++ b/app/src/lib/gallery_path_utils/galleryPathUtils.spec.ts
@@ -491,6 +491,7 @@ describe('isValidImageName', () => {
         'newName.jpeg',
         'new-name.jpg',
         'new_name.jpg',
+        'monkey_river_15_howler_monkey_calling.jpg', // long filename regression test
     ];
     validImageNames.forEach((imageName) => {
         test(`Should be valid: [${imageName}]`, async () => {
@@ -651,6 +652,25 @@ describe('isValidMediaNameStrict', () => {
         test(`Should be valid: [${mediaName}]`, async () => {
             expect(isValidMediaNameStrict(mediaName)).toBe(true);
         });
+    });
+
+    // Regression test for ReDoS vulnerability: long filenames with underscores
+    // must complete quickly, not hang due to catastrophic backtracking
+    test('Should handle long filenames with multiple underscores without hanging', () => {
+        const longValidName = 'monkey_river_15_howler_monkey_calling.mov';
+        const longInvalidName = 'monkey_river_15_howler_monkey_calling_.mov'; // trailing underscore
+
+        const startValid = performance.now();
+        expect(isValidMediaNameStrict(longValidName)).toBe(true);
+        const validTime = performance.now() - startValid;
+
+        const startInvalid = performance.now();
+        expect(isValidMediaNameStrict(longInvalidName)).toBe(false);
+        const invalidTime = performance.now() - startInvalid;
+
+        // Both should complete in under 100ms (was hanging for 100+ seconds before fix)
+        expect(validTime).toBeLessThan(100);
+        expect(invalidTime).toBeLessThan(100);
     });
 });
 
@@ -906,6 +926,7 @@ describe('isValidVideoName', () => {
         'new-name.mp4',
         'new_name.mp4',
         'VIDEO.MOV',
+        'monkey_river_15_howler_monkey_calling.mov', // long filename regression test
     ];
     validVideoNames.forEach((videoName) => {
         test(`Should be valid: [${videoName}]`, async () => {

--- a/app/src/lib/gallery_path_utils/galleryPathUtils.ts
+++ b/app/src/lib/gallery_path_utils/galleryPathUtils.ts
@@ -173,7 +173,8 @@ export function isValidVideoName(videoName: string): boolean {
  */
 export function isValidVideoNameStrict(videoName: string): boolean {
     const extPattern = VIDEO_EXTENSIONS.join('|');
-    const pattern = new RegExp(`^[a-z0-9]+([a-z0-9_]*[a-z0-9]+)*\\.(${extPattern})$`);
+    // Use non-backtracking pattern to avoid ReDoS with long filenames
+    const pattern = new RegExp(`^[a-z0-9]([a-z0-9_]*[a-z0-9])?\\.(${extPattern})$`);
     return pattern.test(videoName);
 }
 
@@ -220,7 +221,8 @@ export function isValidImageName(imageName: string): boolean {
  */
 export function isValidImageNameStrict(imageName: string): boolean {
     const extPattern = IMAGE_EXTENSIONS_STRICT.join('|');
-    const pattern = new RegExp(`^[a-z0-9]+([a-z0-9_]*[a-z0-9]+)*\\.(${extPattern})$`);
+    // Use non-backtracking pattern to avoid ReDoS with long filenames
+    const pattern = new RegExp(`^[a-z0-9]([a-z0-9_]*[a-z0-9])?\\.(${extPattern})$`);
     return pattern.test(imageName);
 }
 


### PR DESCRIPTION
Media rename operations were timing out (taking over 100 seconds) for long filenames like `monkey_river_15_howler_monkey_calling.mov`.  This was due to a regex bug!  

## Summary
- Fixed catastrophic regex backtracking (ReDoS) in `isValidImageNameStrict()` and `isValidVideoNameStrict()`
- The nested quantifier pattern `([a-z0-9_]*[a-z0-9]+)*` caused exponential backtracking with long filenames
- Media rename operations were timing out (100+ seconds) for files like `monkey_river_15_howler_monkey_calling.mov`

## Changes
- Simplified regex from `^[a-z0-9]+([a-z0-9_]*[a-z0-9]+)*` to `^[a-z0-9]([a-z0-9_]*[a-z0-9])?`
- Added regression test that verifies long filenames complete validation in <100ms
- Added long filename test cases to non-strict validators as additional regression protection

## Test plan
- [x] All 1285 unit tests pass
- [x] Verified the old regex hangs on non-matching long filenames (killed after 2+ minutes at 100% CPU)
- [x] Verified the new regex completes in <1ms for the same inputs
- [ ] Manual test: rename a file with a long name like `monkey_river_15_howler_monkey_calling.mov`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filename validation performance, particularly for long names containing underscores.
  * Optimized validation logic to ensure rapid processing and prevent performance delays.

* **Tests**
  * Added regression tests verifying long filename support and validating performance stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->