### PR TITLE
fix: reject consecutive underscores in strict media name validation

### DIFF
--- a/app/src/lib/gallery_path_utils/galleryPathUtils.spec.ts
+++ b/app/src/lib/gallery_path_utils/galleryPathUtils.spec.ts
@@ -539,6 +539,9 @@ describe('isValidImageNameStrict', () => {
         '__.jpg',
         '_image.jpg', // _ at beginning
         'image_.jpg', // _ at end
+        'a__b.jpg', // consecutive underscores
+        'photo__1.jpg', // consecutive underscores
+        'a___b.jpg', // multiple consecutive underscores
     ];
     invalidImageNamesStrict.forEach((imageName) => {
         test(`Should be invalid: [${imageName}]`, async () => {
@@ -591,6 +594,9 @@ describe('isValidVideoNameStrict', () => {
         '__.mp4',
         '_video.mp4', // _ at beginning
         'video_.mp4', // _ at end
+        'a__b.mp4', // consecutive underscores
+        'video__1.mp4', // consecutive underscores
+        'a___b.mp4', // multiple consecutive underscores
     ];
     invalidVideoNamesStrict.forEach((videoName) => {
         test(`Should be invalid: [${videoName}]`, async () => {
@@ -630,6 +636,10 @@ describe('isValidMediaNameStrict', () => {
         'a-b.mp4', // hyphen
         '_image.jpg', // _ at beginning
         '_video.mp4', // _ at beginning
+        'a__b.jpg', // consecutive underscores
+        'a__b.mp4', // consecutive underscores
+        'photo__1.jpg', // consecutive underscores
+        'video__1.mp4', // consecutive underscores
     ];
     invalidMediaNamesStrict.forEach((mediaName) => {
         test(`Should be invalid: [${mediaName}]`, async () => {
@@ -655,23 +665,15 @@ describe('isValidMediaNameStrict', () => {
     });
 
     // Regression test for ReDoS vulnerability: long filenames with underscores
-    // must complete quickly, not hang due to catastrophic backtracking
-    test('Should handle long filenames with multiple underscores without hanging', () => {
+    // must complete quickly, not hang due to catastrophic backtracking.
+    // The 50ms timeout ensures the test fails if the regex causes backtracking.
+    test('Should handle long filenames with multiple underscores without hanging (ReDoS prevention)', () => {
         const longValidName = 'monkey_river_15_howler_monkey_calling.mov';
-        const longInvalidName = 'monkey_river_15_howler_monkey_calling_.mov'; // trailing underscore
+        const longInvalidName = 'monkey_river_15_howler_monkey_calling_.mov';
 
-        const startValid = performance.now();
         expect(isValidMediaNameStrict(longValidName)).toBe(true);
-        const validTime = performance.now() - startValid;
-
-        const startInvalid = performance.now();
         expect(isValidMediaNameStrict(longInvalidName)).toBe(false);
-        const invalidTime = performance.now() - startInvalid;
-
-        // Both should complete in under 100ms (was hanging for 100+ seconds before fix)
-        expect(validTime).toBeLessThan(100);
-        expect(invalidTime).toBeLessThan(100);
-    });
+    }, 50);
 });
 
 describe('getParentAndNameFromPath', () => {

--- a/app/src/lib/gallery_path_utils/galleryPathUtils.ts
+++ b/app/src/lib/gallery_path_utils/galleryPathUtils.ts
@@ -173,8 +173,10 @@ export function isValidVideoName(videoName: string): boolean {
  */
 export function isValidVideoNameStrict(videoName: string): boolean {
     const extPattern = VIDEO_EXTENSIONS.join('|');
-    // Use non-backtracking pattern to avoid ReDoS with long filenames
-    const pattern = new RegExp(`^[a-z0-9]([a-z0-9_]*[a-z0-9])?\\.(${extPattern})$`);
+    // Pattern: alphanumeric start, then optional groups of (single underscore + alphanumeric)
+    // ReDoS-safe because _ and [a-z0-9] are disjoint character classes (no ambiguity)
+    // Also rejects consecutive underscores (each _ must be followed by alphanumeric)
+    const pattern = new RegExp(`^[a-z0-9]+(_[a-z0-9]+)*\\.(${extPattern})$`);
     return pattern.test(videoName);
 }
 
@@ -221,8 +223,10 @@ export function isValidImageName(imageName: string): boolean {
  */
 export function isValidImageNameStrict(imageName: string): boolean {
     const extPattern = IMAGE_EXTENSIONS_STRICT.join('|');
-    // Use non-backtracking pattern to avoid ReDoS with long filenames
-    const pattern = new RegExp(`^[a-z0-9]([a-z0-9_]*[a-z0-9])?\\.(${extPattern})$`);
+    // Pattern: alphanumeric start, then optional groups of (single underscore + alphanumeric)
+    // ReDoS-safe because _ and [a-z0-9] are disjoint character classes (no ambiguity)
+    // Also rejects consecutive underscores (each _ must be followed by alphanumeric)
+    const pattern = new RegExp(`^[a-z0-9]+(_[a-z0-9]+)*\\.(${extPattern})$`);
     return pattern.test(imageName);
 }
 


### PR DESCRIPTION
## Summary
- Fix bug where strict media name validation allowed consecutive underscores like `a__b.jpg`
- Port improved regex pattern from SvelteKit sister project
- Simplify ReDoS regression test to use Jest timeout

## Test plan
- [x] Unit tests pass (added tests for consecutive underscore rejection)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for image, video, and media filenames to reject invalid naming patterns more effectively.
  * Optimized filename validation performance for enhanced responsiveness.

* **Tests**
  * Added comprehensive test coverage for edge cases in filename validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->