### PR TITLE
fix: display portrait videos correctly

### DIFF
--- a/app/src/lambdas/processMediaUpload/processVideoUpload.ts
+++ b/app/src/lambdas/processMediaUpload/processVideoUpload.ts
@@ -99,7 +99,9 @@ async function createMediaConvertJob(
                             Tracks: [1],
                         },
                     },
-                    VideoSelector: {},
+                    VideoSelector: {
+                        Rotate: 'AUTO', // Auto-detect and apply rotation from source metadata (fixes portrait iPhone videos)
+                    },
                     TimecodeSource: 'ZEROBASED',
                 },
             ],


### PR DESCRIPTION
## Summary

- iPhone videos shot in portrait mode are encoded in landscape with rotation metadata
- MediaConvert was not applying this metadata, causing portrait videos to display incorrectly
- Added `Rotate: 'AUTO'` to `VideoSelector` to auto-detect and apply rotation during transcoding

## Test plan

- [ ] Upload a portrait video from iPhone
- [ ] Verify the transcoded video displays in portrait orientation
- [ ] Verify the poster image has correct orientation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic rotation detection for portrait-oriented videos during upload, ensuring videos shot on iPhones and other devices display in the correct orientation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->